### PR TITLE
eliminating template from WG index and fixing links on form WG

### DIFF
--- a/content/docs/procedures/form-new-working-group.md
+++ b/content/docs/procedures/form-new-working-group.md
@@ -105,11 +105,10 @@ The basic steps to setup a working group are as follows:
   listed and a link to their directory in this repository should also be included. See the
   traits working group [as an example][team_repo_example]. This will ensure that the working groups
   are listed on the website.
-- Add a check-in for your working group to the [compiler-team meeting check-in list](check_in)
+- Add a check-in for your working group to the [`compiler-team meeting check-in list`][check_in]
 
 [team_repo]: https://github.com/rust-lang/team
 [team_repo_example]: https://github.com/rust-lang/team/blob/master/teams/wg-traits.toml
-
-[check_in]: ../../about/triage-meeting
+[check_in]:../../about/triage-meeting/
 [README]: https://github.com/rust-lang/compiler-team/blob/master/procedures/README.md
 [template]: ../../working-groups/template/_index

--- a/content/docs/procedures/form-new-working-group.md
+++ b/content/docs/procedures/form-new-working-group.md
@@ -17,11 +17,12 @@ produce those regular updates.
 ## Step 1. Propose the working group
 
 **TBD** -- ironically, we haven't *quite* decided what the procedure
-is for this!  For now, a good idea is to hop on to #t-compiler on [the
+is for this!  For now, a good idea is to hop on to [#t-compiler] on [the
 Zulip][cp] and open up a new topic to discuss your idea. Or,
 alternatively, join a meeting and leave a few comments.
 
-[cp]: ../about/chat-platform.md
+[cp]: ../../about/chat-platform
+
 
 A good goal for this process is to try and identify a small number of
 **achievable deliverables**. It will be easiest to manage a working
@@ -99,7 +100,7 @@ The basic steps to setup a working group are as follows:
     working groups start out with relatively little structure but
     define it early on.
 - **Add an entry to the compiler team calendar:** If you have a regular meeting,
-  ping somebody on `#t-compiler`[cp] to add an entry to the compiler team calendar.
+  ping somebody on [`#t-compiler`][cp] to add an entry to the compiler team calendar.
 - Add a file to the [`rust-lang/team`][team_repo] repository. Only working group leads should be
   listed and a link to their directory in this repository should also be included. See the
   traits working group [as an example][team_repo_example]. This will ensure that the working groups
@@ -109,6 +110,6 @@ The basic steps to setup a working group are as follows:
 [team_repo]: https://github.com/rust-lang/team
 [team_repo_example]: https://github.com/rust-lang/team/blob/master/teams/wg-traits.toml
 
-[check_in]: ../about/triage-meeting.md
-[README]: ../README.md
-[template]: ../working-groups/.template
+[check_in]: ../../about/triage-meeting
+[README]: https://github.com/rust-lang/compiler-team/blob/master/procedures/README.md
+[template]: ../../working-groups/template/_index

--- a/content/docs/working-groups/_index.md
+++ b/content/docs/working-groups/_index.md
@@ -34,13 +34,6 @@ that other interested parties can find out about the meeting. If meetings are no
 would still be desirable to keep the `NOTES.md` in the working group's directory
 up-to-date.
 
-### Template
-New working groups should add a subdirectory and can include the contents of the `.template` folder,
-adding their own details. Each new working group should also added to the list in `README` at the
-root of this repository.
-
-<a href="/docs/working-groups/template"> Go to template </a>
-
 ### Membership
 Typically working groups don't have formal members outside of the specified leads. Those interested
 in participating in a working group can instead subscribe to the working group in order to be added


### PR DESCRIPTION
Fixing issues:
⭐️ Eliminating the Template section on the Working Group index
⭐️ Fixing links con the procedures/form working group 